### PR TITLE
Improve readme.md with useful configuration options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ I run this on a Raspberry Pi Zero W that I have connected to my "Smarty" meter u
 
 ## Before you start
 
-* Ask you energy provider for your decryption key. This might take a few days.
+* Ask you energy provider for your decryption key. This might take a few days. You might want to request from LuxMetering the activation of the full read-out on your smart-meter if you want to get instant voltage/current readings per phase.
 * You need a cable to connect your Raspberry Pi (or whatever else you want to use) to the "P1 port" of your smart meter. Those cables are available under different names: "DSMR cable", "P1 cable" or "slimme meter kabel" (which is Dutch for "smart meter cable").
 * You need to install the "cryptography" and "serial" libraries for Python. Ubuntu/Debian: ``sudo apt-get install python3-cryptography python3-serial``
 * You might need to install "socat" for the examples below. Ubuntu/Debian: ``sudo apt-get install socat``
@@ -74,18 +74,18 @@ Then create a custom configuration:
 sudo nano /etc/supervisor/conf.d/smarty_dsmr_proxy.conf
 ```
 
-My configuration looks like this. Don't forget to use your individual decryption key and adjust the port name to what "socat" uses (see above):
+My configuration looks like this. Don't forget to use your individual decryption key. To cope with the changing pts numbers, it is easiest to use the "link=" option of socat to create a symbolic name with a fixed name (if you want this link in /dev, socat will have to run as root, and you may need to use the "group=" and "mode=" options of socat so that the proxy can still write on the pts). If you use a second pts as local end point, you can use the same option on the second 'pty' block to provide a fixed name for this as well:
 
 ```
 [program:socat]
-command=socat -d -d pty,raw,echo=0 TCP-LISTEN:2001,reuseaddr
+command=socat -d -d pty,raw,echo=0,link=/home/pi/smarty_proxy_pts TCP-LISTEN:2001,reuseaddr
 priority=10
 autostart=true
 autorestart=true
 user=pi
 
 [program:smarty_dsmr_proxy]
-command=python3 /home/pi/smarty_dsmr_proxy/decrypt.py DECRYPTION_KEY --serial-output-port=/dev/pts/1
+command=python3 /home/pi/smarty_dsmr_proxy/decrypt.py DECRYPTION_KEY --serial-output-port=/home/pi/smarty_proxy_pts
 priority=20
 autostart=true
 autorestart=true


### PR DESCRIPTION
By default, the Smarty no longer deliver the full list of Orbis items in the telegrams on the P1 interface, this was de-activated in more recent Firmware versions, levaving just the basisc info:

/Lux5\xxxxxxxxx_D

1-3:0.2.8(42)
0-0:1.0.0(190610152808S)
0-0:42.0.0(xxxxxxxxxxxxxxxxxxxxxxxxxxx)
1-0:1.8.0(002903.121*kWh)
1-0:2.8.0(000000.002*kWh)
1-0:3.8.0(000061.424*kvarh)
1-0:4.8.0(000353.456*kvarh)
1-0:1.7.0(00.614*kW)
1-0:2.7.0(00.000*kW)
1-0:3.7.0(00.000*kvar)
1-0:4.7.0(00.000*kvar)
0-0:17.0.0(27.600*kVA)
0-0:96.3.10(1)
0-0:96.13.0()
0-0:96.13.2()
0-0:96.13.3()
0-0:96.13.4()
0-0:96.13.5()
!AFC7

They are looking into re-activating the full output, and it may be possible to activate it from remote, but definitively only upon request.


I also added information about some socat switches that I found to be useful ( link=, group=, mode=) when configuring the proxy to be used with dsm_reader