### PR TITLE
verify separator

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -124,8 +124,13 @@ class SmartyProxy():
 
         # System title has been read.
         elif self._state == self.STATE_HAS_SYSTEM_TITLE:
-            self._next_state = self._next_state + 1
-            self._state = self.STATE_HAS_SYSTEM_TITLE_SUFFIX  # Ignore separator byte
+            if hex_input == b'82':
+                self._next_state = self._next_state + 1
+                self._state = self.STATE_HAS_SYSTEM_TITLE_SUFFIX  # Ignore separator byte
+            else:
+                print("ERROR, expected 0x82 separator byte not found, dropping frame")
+                self._state = self.STATE_IGNORING
+ 
 
         # Additional byte after the system title has been read.
         elif self._state == self.STATE_HAS_SYSTEM_TITLE_SUFFIX:


### PR DESCRIPTION
Verify separator byte value, to ensure that we're indeed at the right position in a valid frame. Otherwise we might mis-detect the start byte (as this could be anywhere in the ciphertext)